### PR TITLE
Refactores stretch.exe. Small fixes for tif2bmp, showi, stega

### DIFF
--- a/cutp.c
+++ b/cutp.c
@@ -1,130 +1,69 @@
+#include "cutp.h"
 
-    /***********************************************
-    *
-    *       file cutp.c
-    *
-    *       Functions: This file contains
-    *          paste_image_piece
-    *          check_cut_and_paste_limits
-    *
-    *       Purpose:
-    *          These functions paste a part of one
-    *          image into another image.
-    *
-    *       External Calls:
-    *          none
-    *
-    *       Modifications:
-    *          3 April 1992 - created
-    *         12 August 1998 - modified to work 
-    *             with an entire image array.
-    *
-    *************************************************/
+void paste_image_piece(sint16_t **the_image,
+                      sint16_t **out_image,
+                      sint32_t il1,
+                      sint32_t ie1,
+                      sint32_t ll1,
+                      sint32_t le1,
+                      sint32_t il2,
+                      sint32_t ie2) 
+{ 
+  sint32_t i = 0, j = 0, limit1 = 0, limit2 = 0;
 
-#include "cips.h"
+  limit1 = ll1 - il1;
+  limit2 = le1 - ie1;
 
+  for(i = 0; i < limit1; i++) {
+    for(j = 0; j < limit2; j++) {
+      out_image[il2 + i][ie2 + j] = the_image[il1 + i][ie1 + j];
+    }
+  }
+}
 
-
-     /*******************************************
-     *
-     *   paste_image_piece(...
-     *
-     *   This function pastes a rectangular
-     *   piece of an image into another image.
-     *   The rectangle to be pasted into the image
-     *   is described by the il1, ie1, ll1, le1
-     *   parameters for the input image.
-     *
-     *******************************************/
-
-paste_image_piece(the_image, out_image, 
-                  il1, ie1, ll1, le1,
-                  il2, ie2)
-   int    il1, ie1, ll1, le1, il2, ie2;
-   short  **the_image,
-          **out_image;
-
+void check_cut_and_paste_limits(sint32_t il1, 
+                                sint32_t ie1, 
+                                sint32_t ll1, 
+                                sint32_t le1, 
+                                sint32_t il2, 
+                                sint32_t ie2, 
+                                sint32_t image1_length, 
+                                sint32_t image1_width,
+                                sint32_t image2_length, 
+                                sint32_t image2_width,
+                                sint16_t *is_ok)
 {
-   int i, j, limit1, limit2;
+  sint16_t result = 1;
 
-   limit1 = ll1-il1;
-   limit2 = le1-ie1;
+  if(il1 < 0 || ie1 < 0) {
+    (void)printf("\nCheck> il1=%d ie1=%d", il1, ie1);
+    result = 0;
+  }
 
-   for(i=0; i<limit1; i++){
-      for(j=0; j<limit2; j++){
-         out_image[il2+i][ie2+j] = the_image[il1+i][ie1+j];
-      }
-   }
+  if(il2 < 0 || ie2 < 0) {
+    (void)printf("\nCheck> il2=%d ie2=%d", il2, ie2);
+    result = 0;
+  }
 
-}  /* ends paste_image_piece */
+  if(ll1 > image1_length) {
+    (void)printf("\nCheck> ll1=%d length=%d", ll1, image1_length);
+    result = 0;
+  }
 
+  if(le1 > image1_width) {
+    (void)printf("\nCheck> le1=%d width=%d", le1, image1_width);
+    result = 0;
+  }
 
+  if((il2 + (ll1 - il1)) > image2_length) {
+    (void)printf("\nCheck> il2=%d length=%d", il2 + (ll1 - il1), image2_length);
+    result = 0;
+  }
 
-     /*******************************************
-     *
-     *   check_cut_and_paste_limits(...
-     *
-     *   This function looks at the line and
-     *   element parameters and ensures that they
-     *   are not bigger than ROWS and COLS.  If
-     *   they are bigger, the last element or
-     *   last line parameters are reduced.
-     *
-     *******************************************/
+  if((ie2 + (le1 - ie1)) > image2_width) {
+    printf("\nCheck> ie2=%d width=%d", ie2 + (le1 - ie1), image2_width);
+    result = 0;
+  }
 
-
-check_cut_and_paste_limits(
-      il1, ie1, 
-      ll1, le1, 
-      il2, ie2, 
-      image1_length, 
-      image1_width,
-      image2_length, 
-      image2_width,
-      is_ok)
-   int il1, ie1, ll1, le1, il2, ie2,
-       image1_length, image1_width,
-       image2_length, image2_width,
-       *is_ok;
-{
-   int result = 1;
-
-   if(  il1 < 0 ||
-        ie1 < 0){
-      printf("\nCheck> il1=%d ie1=%d", il1, ie1);
-      result = 0;
-   }
-
-   if(  il2 < 0 ||
-        ie2 < 0){
-      printf("\nCheck> il2=%d ie2=%d", il2, ie2);
-      result = 0;
-   }
-
-   if(ll1 > image1_length){
-      printf("\nCheck> ll1=%d length=%d",
-         ll1, image1_length);
-      result = 0;
-   }
-
-   if(le1 > image1_width){
-      printf("\nCheck> le1=%d width=%d",
-         le1, image1_width);
-      result = 0;
-   }
-
-   if((il2+(ll1-il1)) > image2_length){
-      printf("\nCheck> il2=%d length=%d",
-         il2+(ll1-il1), image2_length);
-      result = 0;
-   }
-
-   if((ie2+(le1-ie1)) > image2_width){
-      printf("\nCheck> ie2=%d width=%d",
-         ie2+(le1-ie1), image2_width);
-      result = 0;
-   }
-
-   *is_ok = result;
-
-}  /* ends check_cut_and_paste_limits */
+  *is_ok = result;
+}

--- a/cutp.h
+++ b/cutp.h
@@ -1,0 +1,68 @@
+/******************************************************************************
+*
+*    file cutp.h
+*
+*    Functions: This file contains
+*        paste_image_piece
+*        check_cut_and_paste_limits
+*
+*    Purpose:
+*        These functions paste a part of one
+*        image into another image.
+*
+*    External Calls:
+*        none
+*
+*    Modifications:
+*         3 April 1992 - created
+*        12 August 1998 - modified to work with an entire image array.
+*        30 July 2015 - Refactored
+*              Iulian-Razvan Matesica, Scoala de Vara - Thales - 2015
+*
+*******************************************************************************/
+#ifndef CUTP_H
+#define CUTP_H
+
+#include "cips.h"
+#include "imageio.h"
+
+/******************************************************************************
+*   
+*   paste_image_piece(...
+*
+*   This function pastes a rectangular piece of an image into another image.
+*   The rectangle to be pasted into the image is described by the il1, ie1, ll1, 
+*   le1 parameters for the input image.
+* 
+*******************************************************************************/
+void paste_image_piece(sint16_t **the_image,
+                      sint16_t **out_image,
+                      sint32_t il1,
+                      sint32_t ie1,
+                      sint32_t ll1,
+                      sint32_t le1,
+                      sint32_t il2,
+                      sint32_t ie2);
+
+/******************************************************************************
+*   
+*   check_cut_and_paste_limits(...
+*
+*   This function looks at the line and element parameters and ensures that 
+*   they are not bigger than ROWS and COLS. If they are bigger, the last 
+*   element or last line parameters are reduced.
+* 
+*******************************************************************************/
+void check_cut_and_paste_limits(sint32_t il1, 
+                                sint32_t ie1, 
+                                sint32_t ll1, 
+                                sint32_t le1, 
+                                sint32_t il2, 
+                                sint32_t ie2, 
+                                sint32_t image1_length, 
+                                sint32_t image1_width,
+                                sint32_t image2_length, 
+                                sint32_t image2_width,
+                                sint16_t *is_ok);
+
+#endif

--- a/maincp.c
+++ b/maincp.c
@@ -1,132 +1,83 @@
+#include "maincp.h"
 
-    /***********************************************
-    *
-    *    file maincp.c
-    *
-    *    Functions: This file contains
-    *       main
-    *
-    *    Purpose:
-    *       This file contains the main calling
-    *       routine for a program which 
-    *       cuts a piece from one image and pastes
-    *       it into another.
-    *
-    *    External Calls:
-    *      imageio.c - create_image_file
-    *                  read_image_array
-    *                  write_image_array
-    *                  get_image_size
-    *                  allocate_image_array
-    *                  free_image_array
-    *      cutp.c - paste_image_piece
-    *               check_cut_and_paste_limits
-    *
-    *    Modifications:
-    *       8 April 1992 - created
-    *      12 August 1998 - modified to work on
-    *           entire image array at once.
-    *      18 September 1998 - modified to work with 
-    *            all I O routines in imageio.c.
-    *
-    *************************************************/
-
-#include "cips.h"
-
-
-
-main(argc, argv)
-   int  argc;
-   char *argv[];
+sint32_t main(sint32_t argc, char_t **argv)
 {
+  sint16_t **the_image = NULL, 
+           **out_image = NULL;
 
-   char     name1[80], name2[80];
-   int      i, is_ok, il1, ie1, ll1, le1,
-            il2, ie2, ll2, le2;
-   long     length1, length2, width1, width2;
-   short    **the_image, **out_image;
+  char_t name1[80] = {0}, 
+         name2[80] = {0};
 
-       /******************************************
-       *
-       *  Interpret the command line parameters.
-       *
-       *******************************************/
+  sint16_t i    = 0, is_ok  = 0, il1  = 0, 
+           ie1  = 0, ll1    = 0, le1  = 0,
+           il2  = 0, ie2    = 0, ll2  = 0, le2 = 0;
 
-   if(argc != 9){
-    printf(
-     "\n"
-     "\n usage: maincp in-file out_file "
-     "in-il in-ie in-ll in-le out-il out-ie"
-     "\n"
-     "\n The image portion is pasted from the "
-     "\n in-file into the out-file"
-     "\n");
-    exit(0);
-   }
+  sint32_t length1  = 0, 
+           length2  = 0, 
+           width1   = 0, 
+           width2   = 0,
+           error    = ERR_NONE;
 
-   strcpy(name1, argv[1]);
-   strcpy(name2, argv[2]);
+  /* Interpret the command line parameters. */
+  if(argc != REQUIRED_PARAMETERS) {
+    (void)printf(
+    "\n"
+    "\n usage: maincp in-file out_file "
+    "in-il in-ie in-ll in-le out-il out-ie"
+    "\n"
+    "\n The image portion is pasted from the "
+    "\n in-file into the out-file"
+    "\n");
 
-   if(does_not_exist(name1)){
-    printf("\nERROR input file %s does not exist",
-             name1);
-    exit(0);
-   }
+    error = ERR_INVALID_NO_OF_ARGS;
+  }
 
-   if(does_not_exist(name2)){
-    printf("\nERROR input file %s does not exist",
-             name2);
-    exit(0);
-   }
+  strcpy(name1, argv[1]);
+  strcpy(name2, argv[2]);
 
-   il1 = atoi(argv[3]);
-   ie1 = atoi(argv[4]);
-   ll1 = atoi(argv[5]);
-   le1 = atoi(argv[6]);
-   il2 = atoi(argv[7]);
-   ie2 = atoi(argv[8]);
+  if(does_not_exist(name1) != 0) {
+    (void)printf("\nERROR input file %s does not exist", name1);
+    error = ERR_NO_INPUT_FILE;
+  }
 
-      /******************************************
-      *
-      *   Read the input image sizes, allocate
-      *   the image array and read the image
-      *   for both images.
-      *
-      ******************************************/
+  if(does_not_exist(name2) != 0) {
+    (void)printf("\nERROR input file %s does not exist", name2);
+    error = ERR_NO_INPUT_FILE;
+  }
 
-   get_image_size(name1, &length1, &width1);
-   get_image_size(name2, &length2, &width2);
+  if(error == ERR_NONE) {
+      il1 = (sint16_t) atoi(argv[3]);
+      ie1 = (sint16_t) atoi(argv[4]);
+      ll1 = (sint16_t) atoi(argv[5]);
+      le1 = (sint16_t) atoi(argv[6]);
+      il2 = (sint16_t) atoi(argv[7]);
+      ie2 = (sint16_t) atoi(argv[8]);
 
-   the_image = allocate_image_array(length1, width1);
-   out_image = allocate_image_array(length2, width2);
+    /* Read the input image sizes, allocate the image array and read 
+       the image for both images. */
+    get_image_size(name1, &length1, &width1);
+    get_image_size(name2, &length2, &width2);
 
-   read_image_array(name1, the_image);
-   read_image_array(name2, out_image);
+    the_image = allocate_image_array(length1, width1);
+    out_image = allocate_image_array(length2, width2);
 
+    read_image_array(name1, the_image);
+    read_image_array(name2, out_image);
 
-       /*************************
-       *
-       *   Paste
-       *
-       **************************/
+    /* Paste */
+    check_cut_and_paste_limits(il1, ie1, ll1, le1, il2, ie2, 
+                  length1, width1, length2, width2, &is_ok);
 
-   check_cut_and_paste_limits(
-      il1, ie1, 
-      ll1, le1, 
-      il2, ie2, 
-      length1, width1,
-      length2, width2,
-      &is_ok);
+    (void)printf("\nMAIN> is_ok=%d", is_ok);
 
-printf("\nMAIN> is_ok=%d", is_ok);
+    if(is_ok) {
+        paste_image_piece(the_image, out_image, il1, ie1, ll1, le1, il2, ie2);
+    }
 
-   if(is_ok)
-      paste_image_piece(the_image, out_image, 
-                        il1, ie1, ll1, le1,
-                        il2, ie2);
+    write_image_array(name2, out_image);
+    free_image_array(out_image, length2);
+    free_image_array(the_image, length1);
+  }
 
-   write_image_array(name2, out_image);
-   free_image_array(out_image, length2);
-   free_image_array(the_image, length1);
-
-}  /* ends main */
+  return error;
+}

--- a/maincp.h
+++ b/maincp.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+*
+*    file maincp.h
+*
+*    Purpose:
+*       This file contains the main calling
+*       routine for a program which 
+*       cuts a piece from one image and pastes
+*       it into another.
+*
+*    External Calls:
+*      imageio.c - create_image_file
+*                  read_image_array
+*                  write_image_array
+*                  get_image_size
+*                  allocate_image_array
+*                  free_image_array
+*      cutp.c - paste_image_piece
+*               check_cut_and_paste_limits
+*
+*    Modifications:
+*       8 April 1992 - created
+*      12 August 1998 - modified to work on
+*           entire image array at once.
+*      18 September 1998 - modified to work with 
+*           all I O routines in imageio.c.
+*      30 July 2015 - Refactored
+*           Iulian-Razvan Matesica, Scoala de Vara - Thales - 2015
+*
+******************************************************************************/
+#ifndef MAINCP_H
+#define MAINCP_H
+
+#include "cips.h"
+#include "imageio.h"
+#include "cutp.h"
+
+#define REQUIRED_PARAMETERS     9
+
+#define ERR_NONE                0
+#define ERR_INVALID_NO_OF_ARGS -1
+#define ERR_NO_INPUT_FILE      -2
+
+#endif

--- a/showi.c
+++ b/showi.c
@@ -23,7 +23,7 @@ sint32_t main(sint32_t argc, char_t **argv)
       // Allocate an image array.
       // Read the image and show it on the screen.
       if(does_not_exist(in_name) != 0) {
-         printf("\nERROR input file %s does not exist", in_name);
+         (void)printf("\nERROR input file %s does not exist", in_name);
          error = ERR_NO_INPUT_FILE;
       }
    }
@@ -44,7 +44,7 @@ sint32_t main(sint32_t argc, char_t **argv)
             show_screen(the_image, il, ie);
          }
 
-         printf("\n\n x=quit j=down k=up h=left l=right"
+         (void)printf("\n\n x=quit j=down k=up h=left l=right"
                 "\nEnter choice and press Enter:  ");
          fgets(response, MAX_NAME_LENGTH, stdin);
 
@@ -76,22 +76,22 @@ sint16_t is_in_image(sint16_t il, sint16_t ie, sint32_t height, sint32_t width)
    sint16_t result = 1;
 
    if(il < 0) {
-      printf("\nil=%d tool small", il);
+      (void)printf("\nil=%d tool small", il);
       result = 0;
    }
 
    if(ie < 0) {
-      printf("\nie=%d tool small", ie);
+      (void)printf("\nie=%d tool small", ie);
       result = 0;
    }
 
    if((sint32_t)(il + SHEIGHT) > height) {
-      printf("\nll=%d tool big", il+SHEIGHT);
+      (void)printf("\nll=%d tool big", il+SHEIGHT);
       result = 0;
    }
 
    if((sint32_t)(ie + SWIDTH) > width) {
-      printf("\nle=%d tool big", ie+SWIDTH);
+      (void)printf("\nle=%d tool big", ie+SWIDTH);
       result = 0;
    }
 
@@ -102,16 +102,16 @@ void show_screen(sint16_t **the_image, sint16_t il, sint16_t ie)
 {
    sint32_t i = 0, j = 0;
 
-   printf("\n     ");
+   (void)printf("\n     ");
    for(i = ie - 1; i < ie - 1 + SWIDTH; i++) {
-      printf("-%3d", i);
+      (void)printf("-%3d", i);
    }
 
    for(i = il - 1; i < il - 1 + SHEIGHT; i++) {
-      printf("\n%4d>", i);
+      (void)printf("\n%4d>", i);
       
       for(j = ie - 1; j < ie - 1 + SWIDTH; j++) {
-         printf("-%3d", the_image[i][j]);
+         (void)printf("-%3d", the_image[i][j]);
       }
    }
 }

--- a/stega.c
+++ b/stega.c
@@ -20,7 +20,7 @@ sint32_t main(sint16_t argc, char_t **argv)
     stega_show_usage();
     error = ERR_INVALID_NO_OF_ARGS;
   } else {
-    printf("Aye!!\n");
+    (void)(void)printf("Aye!!\n");
     if(strcmp(argv[1], "-h") == 0) {
       hide    = 1;
       uncover = 0;
@@ -28,8 +28,8 @@ sint32_t main(sint16_t argc, char_t **argv)
       hide    = 0;
       uncover = 1;
     } else if(hide == 0 && uncover == 0) {
-      printf("\nNiether hiding nor uncovering");
-      printf("\nSo, quitting\n");
+      (void)(void)printf("\nNiether hiding nor uncovering");
+      (void)(void)printf("\nSo, quitting\n");
       error = ERR_INVALID_COMMAND;
     } else {
       // Does nothing
@@ -44,9 +44,9 @@ sint32_t main(sint16_t argc, char_t **argv)
     // Hide the cover image in the message image.
     if(hide) {
       if(does_not_exist(cover_image_name)) {
-        printf("\n%s does not exist, quitting", cover_image_name);
+        (void)printf("\n%s does not exist, quitting", cover_image_name);
       } else  if(does_not_exist(message_image_name)) {
-        printf("\n%s does not exist, quitting", message_image_name);
+        (void)printf("\n%s does not exist, quitting", message_image_name);
       }
 
       // Ensure both images have the same height and the cover image is 
@@ -56,14 +56,14 @@ sint32_t main(sint16_t argc, char_t **argv)
       get_image_size(message_image_name, &mlength, &mwidth);
 
       if(mlength != clength) {
-        printf("\n\nmlength NOT EQUAL TO clength");
-        printf("\nQUITING");
+        (void)printf("\n\nmlength NOT EQUAL TO clength");
+        (void)printf("\nQUITING");
         error = ERR_INVALID_ARGS;
       }
 
       if(cwidth != (n*mwidth)) {
-        printf("\nCover image not wide enough");
-        printf("\nQUITING");
+        (void)printf("\nCover image not wide enough");
+        (void)printf("\nQUITING");
         error = ERR_INVALID_ARGS;
       }
 
@@ -87,10 +87,10 @@ sint32_t main(sint16_t argc, char_t **argv)
     if(error == ERR_NONE) {
       // Uncover the cover image from the  message image.
       if(uncover) {
-        printf("\nMAIN> Uncover");
+        (void)printf("\nMAIN> Uncover");
 
         if(does_not_exist(cover_image_name)){
-           printf("\n%s does not exist, quitting", cover_image_name);
+           (void)printf("\n%s does not exist, quitting", cover_image_name);
         }
 
         // Create the message image to be the correct size.
@@ -174,7 +174,7 @@ sint16_t hide_pixels(sint16_t **cover_image,
     0x7F   /* 0111 1111 */
   };
 
-  printf("\nHP> mie=%d   cie=%d   lsb=%d", mie, cie, lsb);
+  (void)printf("\nHP> mie=%d   cie=%d   lsb=%d", mie, cie, lsb);
 
   for(i = 0; i < mlength; i++) {
     c_counter = 0;
@@ -266,7 +266,7 @@ sint16_t uncover_pixels(sint16_t **cover_image,
   sint16_t c = 0, c_counter = 0;
   sint32_t i = 0, j = 0;
 
-  printf("\nUP> mie=%d   cie=%d   lsb=%d", mie, cie, lsb);
+  (void)printf("\nUP> mie=%d   cie=%d   lsb=%d", mie, cie, lsb);
   // If a pixel in the cover image is odd, its lsb has been set, so 
   // the corresponding bit in the message image should be set.
   for(i = 0; i < mlength; i++) {
@@ -298,9 +298,9 @@ sint16_t is_odd(int16_t number)
 
 void stega_show_usage(void)
 {
-  printf("\n\nNot enough parameters:");
-  printf("\n");
-  printf("   "
+  (void)printf("\n\nNot enough parameters:");
+  (void)printf("\n");
+  (void)printf("   "
           "\nstega -h cover-image-name message-image-name n"
           "\n       to hide the message image in the cover image"
           "\n                 or"

--- a/stretch.c
+++ b/stretch.c
@@ -1,197 +1,119 @@
+#include "stretch.h"
 
+static sint16_t **the_image = NULL;
+static sint16_t **out_image = NULL;
 
-    /********************************************
-    *
-    *   file stretch.c
-    *
-    *   Functions: This file contains
-    *      main
-    *      stretch
-    *      bilinear_interpolate
-    *
-    *   Purpose:
-    *      This file contains the main calling
-    *      routine and the needed subroutines
-    *      for a program which stretches
-    *      an image by any factor.  It can either
-    *      roundoff the numbers or use
-    *      bi-linear interpolation.
-    *
-    *   External Calls:
-    *      imageio.c - create_resized_image_file
-    *                  read_image_array
-    *                  write_image_array
-    *                  get_image_size
-    *                  allocate_image_array
-    *                  free_image_array
-    *
-    *   Modifications:
-    *      4 December 1993 - created
-    *     16 September 1998 - modified to work on entire
-    *         images at one time.
-    *     22 September 1998 - modified to work with 
-    *           all I O routines in imageio.c.
-    *
-    *********************************************/
-
-#include "cips.h"
-#define FILL 150
-
-
-short **the_image;
-short **out_image;
-
-main(argc, argv)
-   int argc;
-   char *argv[];
+sint32_t main(sint16_t argc, char_t **argv)
 {
+  char_t in_name[80] = {0}, out_name[80] = {0};
+  float    x_stretch, y_stretch;
+  sint16_t bilinear    = 0; 
 
-   char     in_name[80], out_name[80];
-
-   float    x_stretch, y_stretch;
-
-   int      bilinear; 
-   long     tmp_length, tmp_width;
-   long     length, width;
+  sint32_t tmp_length  = 0, 
+           tmp_width   = 0,
+           length      = 0, 
+           width       = 0,
+           error       = ERR_NONE;
    
-   struct bmpfileheader      bmp_file_header;
-   struct bitmapheader       bmheader;
-   struct bitmapheader       bmheader2;
-   struct tiff_header_struct tiff_file_header;
-   struct tiff_header_struct tiff_file_header2;
+  bmpfileheader      bmp_file_header;
+  bitmapheader       bmheader;
+  bitmapheader       bmheader2;
+  tiff_header_struct tiff_file_header;
+  tiff_header_struct tiff_file_header2;
 
-       /******************************************
-       *
-       *  Interpret the command line parameters.
-       *
-       *******************************************/
+  /* Interpret the command line parameters. */
+  if(argc < REQUIRED_PARAMETERS || argc > REQUIRED_PARAMETERS){
+    (void)printf("\nn usage: stretch in-file out-file x-stretch "
+           "y-stretch bilinear (1 or 0)\n");
 
-   if(argc < 6 || argc > 6){
-    printf(
-     "\n"
-     "\n usage: stretch in-file out-file x-stretch "
-     "y-stretch bilinear (1 or 0)"
-     "\n");
-    exit(0);
-   }
+    error = ERR_INVALID_NO_OF_ARGS;
+  }
 
-   strcpy(in_name,  argv[1]);
-   strcpy(out_name, argv[2]);
-   x_stretch = atof(argv[3]);
-   y_stretch = atof(argv[4]);
-   bilinear  = atoi(argv[5]);
+  if(error == ERR_NONE) {
+    strcpy(in_name,  argv[1]);
+    strcpy(out_name, argv[2]);
+    x_stretch = (float) atof(argv[3]);
+    y_stretch = (float) atof(argv[4]);
+    bilinear  = (float) atoi(argv[5]);
 
-   if(does_not_exist(in_name)){
-    printf("\nERROR input file %s does not exist",
-             in_name);
-    exit(0);
-   }
+    if(does_not_exist(in_name) != 0){
+      (void)printf("\nERROR input file %s does not exist", in_name);
+      error = ERR_NO_INPUT_FILE;
+    } 
+  }
 
-       /********************************************
-       *
-       *   Create an output file different in size
-       *   from the input file.
-       *
-       ********************************************/
+  if(error == ERR_NONE) {
+    /* Create an output file different in size */
+    get_image_size(in_name, &length, &width);
+    tmp_length = ((float)(length) * y_stretch);
+    tmp_width  = ((float)(width) * x_stretch);
+    create_resized_image_file(in_name, out_name, tmp_length, tmp_width);
 
-   get_image_size(in_name, &length, &width);
-   tmp_length = ((float)(length)*y_stretch);
-   tmp_width  = ((float)(width)*x_stretch);
-   create_resized_image_file(in_name, out_name,
-                             tmp_length, tmp_width);
+    the_image = allocate_image_array(length, width);
+    out_image = allocate_image_array(tmp_length, tmp_width);
 
-   the_image = allocate_image_array(length, width);
-   out_image = allocate_image_array(tmp_length, tmp_width);
+    read_image_array(in_name, the_image);
+    stretch(the_image, out_image,
+            x_stretch, y_stretch,
+            bilinear,
+            tmp_length,
+            tmp_width,
+            length,
+            width);
 
-   read_image_array(in_name, the_image);
+    write_image_array(out_name, out_image);
+    free_image_array(out_image, tmp_length);
+    free_image_array(the_image, length);
+  }
 
-   stretch(the_image, out_image,
-           x_stretch, y_stretch,
-           bilinear,
-           tmp_length,
-           tmp_width,
-           length,
-           width);
+  return error;
+}
 
-   write_image_array(out_name, out_image);
-   free_image_array(out_image, tmp_length);
-   free_image_array(the_image, length);
-
-}  /* ends main  */
-
-
-
-
-     /*******************************************
-     *
-     *   stretch(..
-     *
-     *   This routine performs the image 
-     *   stretching. If bilinear == 0, it uses 
-     *   the roundoff approach for enlarging 
-     *   an area. If bilinear == 1, it calls the 
-     *   bilinear_interpolate routine to get 
-     *   the value of a pixel that lies 
-     *   between pixels.
-     *
-     ********************************************/
-
-stretch(the_image, out_image,
-        x_stretch, y_stretch,
-        bilinear,
-        out_rows, out_cols,
-        in_rows,  in_cols)
-
-   float  x_stretch, y_stretch;
-   int    bilinear;
-   short  **the_image,
-          **out_image;
-   long   out_cols, out_rows;
-   long   in_cols,  in_rows;
+void stretch(sint16_t **the_image, 
+             sint16_t **out_image,
+             float x_stretch, 
+             float y_stretch,
+             sint16_t bilinear,
+             sint32_t out_rows, 
+             sint32_t out_cols,
+             sint32_t in_rows,
+             sint32_t in_cols)
 {
-   double tmpx, tmpy;
-   float  fi, fj;
-   int    i, j, new_i, new_j;
+  double tmpx = 0.0d, tmpy = 0.0d;
+  float  fi = 0.0f, fj = 0.0f;
+  sint16_t i = 0, j = 0, new_i = 0, new_j = 0;
 
-      /**************************
-      *
-      *   Loop over image array
-      *
-      **************************/
+  /* Loop over image array */
+  (void)printf("\n");
 
-   printf("\n");
-   for(i=0; i<out_rows; i++){
-      if( (i%10) == 0) printf("%d ", i);
-      for(j=0; j<out_cols; j++){
+  for(i = 0; i < out_rows; i++) {
+    if((i % 10) == 0) {
+      (void)printf("%d ", i);
+    }
+      
+    for(j = 0; j < out_cols; j++) {
+      fi = i;
+      fj = j;
 
-         fi = i;
-         fj = j;
+      tmpx = fj/x_stretch;
+      tmpy = fi/y_stretch;
 
-         tmpx = fj/x_stretch;
-         tmpy = fi/y_stretch;
+      new_i = tmpy;
+      new_j = tmpx;
 
-         new_i = tmpy;
-         new_j = tmpx;
-
-         if(bilinear == 0){
-            if(new_j < 0       ||
-               new_j >= in_cols   ||
-               new_i < 0       ||
-               new_i >= in_rows)
-               out_image[i][j] = FILL;
-            else
-               out_image[i][j] =
-                the_image[new_i][new_j];
-         }  /* ends if bilinear */
-         else{
-            out_image[i][j] =
-               bilinear_interpolate(the_image,
-                                    tmpx, tmpy,
-                                    in_rows, in_cols);
-         }  /* ends bilinear if */
-
-      }  /* ends loop over j */
-   }  /* ends loop over i */
-
-}  /* ends stretch */
+      if(bilinear == 0) {
+        if(new_j < 0 || new_j >= in_cols || new_i < 0 || new_i >= in_rows) {
+            out_image[i][j] = FILL;
+        }
+        else {
+          out_image[i][j] = the_image[new_i][new_j];
+        }
+      }
+      else{
+        out_image[i][j] = bilinear_interpolate(the_image, tmpx, 
+                              tmpy, in_rows, in_cols);
+      }
+    }
+  }
+}
 

--- a/stretch.h
+++ b/stretch.h
@@ -1,0 +1,68 @@
+/******************************************************************************
+*
+*   file stretch.h
+*
+*   Purpose:
+*      This file contains the main calling
+*      routine and the needed subroutines
+*      for a program which stretches
+*      an image by any factor.  It can either
+*      roundoff the numbers or use
+*      bi-linear interpolation.
+*
+*   External Calls:
+*      imageio.c - create_resized_image_file
+*                  read_image_array
+*                  write_image_array
+*                  get_image_size
+*                  allocate_image_array
+*                  free_image_array
+*
+*   Modifications:
+*      4 December 1993 - created
+*     16 September 1998 - modified to work on entire
+*         images at one time.
+*     22 September 1998 - modified to work with 
+*         all I O routines in imageio.c.
+*     30 July 2015 - Refactored
+*         Iulian-Razvan Matesica, Scoala de Vara - Thales - 2015
+*
+******************************************************************************/
+#ifndef STRETCH_H
+#define STRETCH_H
+
+#include "mtypes.h"
+#include "imageio.h"
+#include "cips.h"
+#include "geosubs.h"
+
+#define FILL 150
+#define REQUIRED_PARAMETERS     6
+
+#define ERR_NONE                0
+#define ERR_INVALID_NO_OF_ARGS -1
+#define ERR_NO_INPUT_FILE      -2
+#define ERR_INPUT_NOT_TIF      -3
+#define ERR_OUTPUT_NOT_BMP     -4
+#define ERR_NO_IMAGE_LOADED    -5
+
+/******************************************************************************
+*
+*   stretch(..
+*
+*   This routine performs the image stretching. If bilinear == 0, it uses 
+*   the roundoff approach for enlarging an area. If bilinear == 1, it 
+*   calls the bilinear_interpolate routine to get the value of a pixel that 
+*   lies between pixels.
+*
+******************************************************************************/
+void stretch(sint16_t **the_image, 
+             sint16_t **out_image,
+             float x_stretch, 
+             float y_stretch,
+             sint16_t bilinear,
+             sint32_t out_rows, 
+             sint32_t out_cols,
+             sint32_t in_rows,
+             sint32_t in_cols);
+#endif

--- a/tif2bmp.c
+++ b/tif2bmp.c
@@ -10,24 +10,24 @@ sint32_t main(sint32_t argc, char_t **argv)
   bitmapheader       bmheader;
    
   if(argc < 3 || argc > 3){
-    printf("\nusage: tif2bmp tif-file-name bmp-file-name\n");
+    (void)printf("\nusage: tif2bmp tif-file-name bmp-file-name\n");
     error = ERR_INVALID_NO_OF_ARGS;
   }
 
   if(does_not_exist(argv[1])){
-    printf("\nERROR input file %s does not exist", argv[1]);
+    (void)printf("\nERROR input file %s does not exist", argv[1]);
     error = ERR_NO_INPUT_FILE;
   }
 
   cc = strstr(argv[1], ".tif");
   if(cc == NULL){  
-    printf("\nERROR %s must be a tiff file", argv[1]);
+    (void)printf("\nERROR %s must be a tiff file", argv[1]);
     error = ERR_INPUT_NOT_TIF;
   }
 
   cc = strstr(argv[2], ".bmp");
   if(cc == NULL){  /* create a bmp */
-    printf("\nERROR %s must be a bmp file name", argv[2]);
+    (void)printf("\nERROR %s must be a bmp file name", argv[2]);
     error = ERR_OUTPUT_NOT_BMP;
   }
 


### PR DESCRIPTION
stretch.c foloseste functii din geosubs.c si vor aparea probleme pentru ca in varianta actuala de geosubs.c sunt folosite tipurile "float32_t", "double32_t" care NU sunt definite in mtypes.h. 

stretch.c foloseste tipurile "float" si "double".
